### PR TITLE
fix: load Google Maps with empty API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The app reads configuration from environment variables:
    -  `SPACEFINDER_SAML_ISSUER`
    -  `SPACEFINDER_SAML_SP_ENTITY_ID` — Defaults to
       `https://${SPACEFINDER_SAML_ISSUER}/shibboleth`
+-  Google Maps
+   -  `SPACEFINDER_GOOGLE_MAPS_API_KEY`
 
 By default the `db:prepare` task is run at container startup, to either create
 the database or run pending migrations. Set `SPACEFINDER_DB_PREPARE` to a value

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,7 @@ class HomeController < ApplicationController
     @details_needed = @user.try(:"details_needed?")
     @status = "success"
     @js_base_url = url_for(action: 'index', only_path: true, trailing_slash: true)
+    @google_maps_api_key = Rails.application.config.google_maps_api_key or ''
     render layout: false
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
     <title>Spacefinder</title>
     <meta charset="utf-8" />
     <!--scripts-->
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA70cwyy9WH6wgv7wrm-skrak2HCeIK2-U&libraries=geometry"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= @google_maps_api_key %>&libraries=geometry"></script>
 
     <!--styles-->
     <%= stylesheet_link_tag "home" %>

--- a/config/initializers/spacefinder.rb
+++ b/config/initializers/spacefinder.rb
@@ -1,0 +1,5 @@
+# Spacefinder application configuration
+
+# The API key used when loading the Google Maps API
+Rails.application.config.google_maps_api_key = Spacefinder.get_file_envar(
+  'SPACEFINDER_GOOGLE_MAPS_API_KEY', '')

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class HomeControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Rails.application.config.google_maps_api_key = ''
+  end
+
+  test "should get index" do
+    get root_url
+    assert_response :success
+    assert_equal "text/html", @response.media_type
+  end
+
+  test "google maps API key is empty by default" do
+    get root_url
+    maps_url = 'https://maps.googleapis.com/maps/api/js?key=&libraries=geometry'
+    assert_select "script:match('src', ?)", Regexp.escape(maps_url)
+  end
+
+  test "google maps API js is requested with API key specified in config" do
+    api_key = 'abcd'
+    Rails.application.config.google_maps_api_key = api_key
+    get root_url
+    maps_url = "https://maps.googleapis.com/maps/api/js?key=#{api_key}&libraries=geometry"
+    assert_select "script:match('src', ?)", Regexp.escape(maps_url)
+  end
+end


### PR DESCRIPTION
The Google Maps JS API was failing to load on localhost due to the API key not permitting that origin. With an empty API key it loads and works as expected on localhost. The `SPACEFINDER_GOOGLE_MAPS_API_KEY` envar can be used to set the API key for a production deployment.